### PR TITLE
Kl/align fields with ai schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 build
 *.egg-info
 .env
+.venv

--- a/langchain_response_tracing/tracers/audit.py
+++ b/langchain_response_tracing/tracers/audit.py
@@ -62,13 +62,13 @@ class PangeaAuditCallbackHandler(BaseTracer):
         self._client.log_bulk(
             [
                 {
-                    "event_trace_id": run.trace_id,
-                    "event_type": "llm/end",
-                    "event_tools": {
+                    "trace_id": run.trace_id,
+                    "type": "llm/end",
+                    "tools": {
                         "invocation_params": run.extra.get("invocation_params", {}),
                         "llm_output": run.outputs.get("llm_output", {}),
                     },
-                    "event_output": x,
+                    "output": x,
                 }
                 for x in text_generations
             ]


### PR DESCRIPTION
The most recent AI Audit Log Schema configs have different fields by default. This PR is to align the tracer fields with the audit log schema.